### PR TITLE
hamonize-agent 에대한 하위 라이선스를 추가하였습니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,6 @@ This project follows the [all-contributors](https://github.com/all-contributors/
 ### 아키텍처
 
 ![architecture](./img/architecture.png)
+
+## 라이선스
+* [hamonize-agent 라이선스 문서](https://github.com/hamonikr/hamonize/blob/master/hamonize-agent/NOTICE.md)

--- a/hamonize-agent/NOTICE.md
+++ b/hamonize-agent/NOTICE.md
@@ -1,0 +1,399 @@
+# OSS Notice | hamonize #
+
+This application is Copyright © HamoniKR. All rights reserved.
+
+The following sets forth attribution notices for third party software that may be contained in this application.
+
+ **@andycasen/withtimeout**
+
+MIT License
+
+ **async-polling**
+
+https://github.com/cGuille/async-polling
+
+Copyright @cGuille
+
+MIT License
+
+ **create-file**
+
+https://github.com/joakimbeng/create-file
+
+Copyright Joakim Carlstein
+
+MIT License
+
+ **date-utils**
+
+https://github.com/JerrySievert/date-utils
+
+Copyright Jerry Sievert
+
+MIT License
+
+ **delay**
+
+https://github.com/sindresorhus/delay
+
+Copyright Sindre Sorhus
+
+MIT License
+
+ **dialog0.3.1**
+
+[https://github.com/tomas/dialog\#readme][https_github.com_tomas_dialog_readme]
+
+Copyright 2012 Fork Ltd. MIT license.
+
+MIT License
+
+ **electron-installer-squirrel-windows**
+
+https://github.com/mongodb-js/electron-installer-squirrel-windows
+
+Copyright Lucas Hrabovsky
+
+Apache License 2.0
+
+ **electron-ipc-promise**
+
+https://github.com/kdepp/electron-ipc-promise
+
+Copyright kdepp
+
+ISC License
+
+ **electron-log**
+
+https://github.com/megahertz/electron-log
+
+Copyright 2016 Alexey Prokhorov
+
+MIT License
+
+ **electron-widevinecdm**
+
+https://github.com/webcatalog/electron-widevinecdm
+
+Copyright Quang Lam
+
+MIT License
+
+ **electron-window-state**
+
+https://github.com/mawie81/electron-window-state
+
+Copyright 2015 Jakub Szwacz
+
+Copyright Marcel Wiehle  (http://marcel.wiehle.me)
+
+MIT License
+
+ **fetch**
+
+https://github.com/andris9/fetch
+
+Copyright Andris Reinman
+
+MIT License
+
+ **fs0.0.1-security**
+
+[https://github.com/npm/security-holder\#readme][https_github.com_npm_security-holder_readme]
+
+Copyright property of respective owners
+
+ISC License
+
+ **json-parser**
+
+https://github.com/kaelzhang/node-json-parser
+
+Copyright kaelzhang
+
+MIT License
+
+ **Node Cron**
+
+https://github.com/merencia/node-cron
+
+Copyright 2016, Lucas Merencia
+
+ISC License
+
+ **Node Fetch**
+
+https://github.com/bitinn/node-fetch
+
+Copyright 2016 - 2020 Node Fetch Team
+
+MIT License
+
+ **Node Schedule**
+
+https://github.com/node-schedule/node-schedule
+
+Copyright 2015 Matt Patenaude
+
+MIT License
+
+ **node-ip**
+
+https://github.com/indutny/node-ip
+
+Copyright Fedor Indutny, 2012.
+
+MIT License
+
+ **node-pre-gyp**
+
+https://github.com/mapbox/node-pre-gyp
+
+Copyright Mapbox
+
+BSD 3-Clause "New" or "Revised" License
+
+ **node-xml2js**
+
+https://github.com/Leonidas-from-XIV/node-xml2js
+
+Copyright 2010, 2011, 2012, 2013.
+
+MIT License
+
+ **ora**
+
+https://github.com/sindresorhus/ora
+
+Copyright Sindre Sorhus  (https://sindresorhus.com)
+
+MIT License
+
+ **ping**
+
+https://github.com/danielzzz/node-ping
+
+Copyright danielzzz
+
+MIT License
+
+ **pkg**
+
+https://github.com/zeit/pkg
+
+MIT License
+
+ **poller**
+
+https://github.com/anephenix/poller
+
+Copyright Paul Jensen
+
+MIT License
+
+ **precise**
+
+https://github.com/avoidwork/precise
+
+Copyright Jason Mulligan
+
+BSD 3-Clause "New" or "Revised" License
+
+ **redux-electron-ipc**
+
+https://github.com/mariotacke/redux-electron-ipc
+
+Copyright Mario Tacke
+
+MIT License
+
+ **request**
+
+https://github.com/request/request
+
+Copyright Mikeal Rogers
+
+Apache License 2.0
+
+ **tenacious-fetch**
+
+https://github.com/tiaanduplessis/tenacious-fetch
+
+Copyright Tiaan du Plessis
+
+MIT License
+
+ **time-counter**
+
+https://www.npmjs.com/package/time-counter
+
+Copyright property of respective owners
+
+MIT License
+
+ **timer-stopwatch**
+
+https://www.npmjs.com/package/timer-stopwatch
+
+Copyright property of respective owners
+
+MIT License
+
+ **winston**
+
+https://github.com/winstonjs/winston
+
+Copyright 2010 Charlie Robbins
+
+MIT License
+
+ **winston-daily-rotate-file**
+
+https://github.com/winstonjs/winston-daily-rotate-file
+
+Copyright 2015 winstonjs
+
+MIT License
+
+ **write**
+
+https://github.com/jonschlinkert/write
+
+Copyright Jon Schlinkert
+
+MIT License
+
+ **xml-js**
+
+https://github.com/nashwaan/xml-js
+
+Copyright 2016-2017 Yousuf Almarzooqi
+
+MIT License
+
+# ISC License #
+
+``````````
+ISC License
+
+Copyright (c) 2004-2010 by Internet Systems Consortium, Inc. ("ISC")
+
+Copyright (c) 1995-2003 by Internet Software Consortium
+
+Permission to use, copy, modify, and /or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND ISC DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL ISC BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+``````````
+
+# Apache License 2.0 #
+
+``````````
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+``````````
+
+# MIT License #
+
+``````````
+MIT License
+
+Copyright (c)  
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+``````````
+
+# BSD 3-Clause "New" or "Revised" License #
+
+``````````
+Copyright (c)   . All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+   3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+``````````
+
+
+[https_github.com_tomas_dialog_readme]: https://github.com/tomas/dialog#readme
+[https_github.com_npm_security-holder_readme]: https://github.com/npm/security-holder#readme


### PR DESCRIPTION
#5 해당 이슈에 대한 pr입니다.

다음과 같은 프로세스를 통해 hamonize-agent 에 대한 하위 라이선스를 추가 고지하였습니다.
1. [해당 문서](https://github.com/NIPA-OpenUP/oss-governance-guide/blob/main/oss-governance-guide.md) 를 통해 라이선스 관리 방법과 자체 검증 방법을 학습하고 이를 정리하여 [산출물](http://pms.invesume.com:8090/pages/viewpage.action?pageId=73337718)을 작성하였습니다.
2. [OLIVE](https://olive.kakao.com/) 를 통해 레포지토리에 현재까지 업로드 된 hamonize-agent 의 컴포넌트와 라이선스를 스캔하였습니다.
3. 검증 결과서를 hamonize/hamonize-agent/NOTICE.md 로 추가하고, 루트의 README에 이에 대한 링크를 추가하였습니다.
4. 해당 문서에는 스캔된 각 컴포넌트의 저작권과 라이선스, 그리고 라이선스 사본이 포함되어 있습니다.