### PR TITLE
#128 hamonize-vpn 이미지 버전을 0.2로 업데이트 했습니다.

### DIFF
--- a/hamonize-vpn/docker-compose.yml
+++ b/hamonize-vpn/docker-compose.yml
@@ -8,7 +8,7 @@ networks:
 
 services:
   hmon_vpn_vpn:
-    image: hamonikr/hamonize-vpn:0.1
+    image: hamonikr/hamonize-vpn:0.2
     container_name: hmon_vpn_vpn
     cap_add:
      - NET_ADMIN


### PR DESCRIPTION
#128 해당 이슈에 대한 pr입니다. docker-compose.yml 파일에서 사용하는 이미지인 hamonize-vpn의 버전을 0.2로 업데이트 했습니다.