### PR TITLE
에이전트] 복구 수행 이전에 로그아웃 접속로그 전송

### DIFF
--- a/hamonize-agent/src/shell/backupJob_recovery.sh
+++ b/hamonize-agent/src/shell/backupJob_recovery.sh
@@ -41,6 +41,8 @@ BK_RECOV_JSON="{\
 }"
 
 echo ${BK_RECOV_JSON} >> ${LOGFILE}
+echo "$DATETIME] logout==========================" >> ${LOGFILE}
+sudo /etc/hamonize/run-script-on-boot.sh logout >> ${LOGFILE}
 
 # RET_RECOV=`curl  -X  POST -H 'User-Agent: HamoniKR OS' -H 'Content-Type: application/json' -f -s -d "$BK_RECOV_JSON" $BK_START_CENTERURL`
 # echo "---------------------->$RET_RECOV">>$LOGFILE

--- a/hamonize-agent/usr/share/hamonize-agent/shell/backupJob_recovery.sh
+++ b/hamonize-agent/usr/share/hamonize-agent/shell/backupJob_recovery.sh
@@ -41,6 +41,8 @@ BK_RECOV_JSON="{\
 }"
 
 echo ${BK_RECOV_JSON} >> ${LOGFILE}
+echo "$DATETIME] logout==========================" >> ${LOGFILE}
+sudo /etc/hamonize/run-script-on-boot.sh logout >> ${LOGFILE}
 
 # RET_RECOV=`curl  -X  POST -H 'User-Agent: HamoniKR OS' -H 'Content-Type: application/json' -f -s -d "$BK_RECOV_JSON" $BK_START_CENTERURL`
 # echo "---------------------->$RET_RECOV">>$LOGFILE


### PR DESCRIPTION
#187 해당 이슈에 대한 pr입니다.
에이전트에서 복구정책 수행 이전에 로그아웃 접속로그를 전송하도록 수정하였습니다.