### PR TITLE
에이전트 프로그램 버전 확인 수정

### DIFF
--- a/hamonize-agent/src/shell/updtjob.sh
+++ b/hamonize-agent/src/shell/updtjob.sh
@@ -37,7 +37,7 @@ do
         echo "install chk is ==> $INS_INSTALL_CHK" >>$LOGFILE
 
 
-        INS_CHK_CNT=`dpkg --get-selections | grep $I | wc -l`
+        INS_CHK_CNT=`dpkg --get-selections | grep $I | grep -v "[[:graph:]]$I\|$I[[:graph:]]" | wc -l`
         echo "install chk wc -l is ==> $INS_CHK_CNT" >>$LOGFILE
 
         INS_WHEREISPROGRM=`whereis $I`
@@ -46,7 +46,7 @@ do
         INS_FILE_PATH=`echo $INS_WHEREISPROGRM | awk '{print $2}'`
         echo "ins_awk is ===>$INS_FILE_PATH" >>$LOGFILE
 
-        INS_PKG_VER=`apt version $I`
+        INS_PKG_VER=`dpkg -l | grep $I | awk '{print $3}'`
  
 
         INSRET=$INSRET"{\"debname\":\"${I}\",\"debver\":\"${INS_PKG_VER}\",\"state\":\"$INS_CHK_CNT\",\"path\":\"$INS_FILE_PATH\"}"
@@ -162,7 +162,7 @@ do
         #         echo "It's the same as the new version and the installed version ===> $INSTALLED_VER" >> $LOGFILE                                       
         # fi
 
-        UPS_CHK_CNT=`dpkg --get-selections | grep $NAME | wc -l`
+        UPS_CHK_CNT=`dpkg --get-selections | grep $NAME | grep -v "[[:graph:]]$NAME\|$NAME[[:graph:]]" | wc -l `
         echo "wc -l is ===>$UPS_CHK_CNT"
 
         UPS_WHEREISPROGRM=`whereis $NAME`
@@ -171,7 +171,7 @@ do
         UPS_FILE_PATH=`echo $UPS_WHEREISPROGRM | awk '{print $2}'`
         echo "ins_awk is ===>$UPS_FILE_PATH" >>$LOGFILE
 
-        UPS_PKG_VER=`apt version $NAME`
+        #UPS_PKG_VER=`apt version $NAME`
 
         UPSRET=$UPSRET"{\"debname\":\"${NAME}\",\"debver\":\"${INSTALLED_VER}\",\"state\":\"$UPS_CHK_CNT\",\"path\":\"$UPS_FILE_PATH\"}"
                         
@@ -232,10 +232,10 @@ do
         sleep 1
 
 
-        DEL_CHK_CNT=`dpkg --get-selections | grep $I | wc -l`
+        DEL_CHK_CNT=`dpkg --get-selections | grep $I | grep -v "[[:graph:]]$I\|$I[[:graph:]]" | wc -l`
         echo "del chk wc -l is ==> $DEL_CHK_CNT" >>$LOGFILE
 
-        DEL_PKG_VER=`apt version $I`
+        DEL_PKG_VER=`dpkg -l | grep $I | awk '{print $3}'`
 
 
         DELRET=$DELRET"{\"debname\":\"${I}\",\"debver\":\"${DEL_PKG_VER}\",\"state\":\"$DEL_CHK_CNT\",\"path\":\"\"}"

--- a/hamonize-agent/usr/share/hamonize-agent/shell/updtjob.sh
+++ b/hamonize-agent/usr/share/hamonize-agent/shell/updtjob.sh
@@ -37,7 +37,7 @@ do
         echo "install chk is ==> $INS_INSTALL_CHK" >>$LOGFILE
 
 
-        INS_CHK_CNT=`dpkg --get-selections | grep $I | wc -l`
+        INS_CHK_CNT=`dpkg --get-selections | grep $I | grep -v "[[:graph:]]$I\|$I[[:graph:]]" | wc -l`
         echo "install chk wc -l is ==> $INS_CHK_CNT" >>$LOGFILE
 
         INS_WHEREISPROGRM=`whereis $I`
@@ -46,7 +46,7 @@ do
         INS_FILE_PATH=`echo $INS_WHEREISPROGRM | awk '{print $2}'`
         echo "ins_awk is ===>$INS_FILE_PATH" >>$LOGFILE
 
-        INS_PKG_VER=`apt version $I`
+        INS_PKG_VER=`dpkg -l | grep $I | awk '{print $3}'`
  
 
         INSRET=$INSRET"{\"debname\":\"${I}\",\"debver\":\"${INS_PKG_VER}\",\"state\":\"$INS_CHK_CNT\",\"path\":\"$INS_FILE_PATH\"}"
@@ -162,7 +162,7 @@ do
         #         echo "It's the same as the new version and the installed version ===> $INSTALLED_VER" >> $LOGFILE                                       
         # fi
 
-        UPS_CHK_CNT=`dpkg --get-selections | grep $NAME | wc -l`
+        UPS_CHK_CNT=`dpkg --get-selections | grep $NAME | grep -v "[[:graph:]]$NAME\|$NAME[[:graph:]]" | wc -l `
         echo "wc -l is ===>$UPS_CHK_CNT"
 
         UPS_WHEREISPROGRM=`whereis $NAME`
@@ -171,7 +171,7 @@ do
         UPS_FILE_PATH=`echo $UPS_WHEREISPROGRM | awk '{print $2}'`
         echo "ins_awk is ===>$UPS_FILE_PATH" >>$LOGFILE
 
-        UPS_PKG_VER=`apt version $NAME`
+        #UPS_PKG_VER=`apt version $NAME`
 
         UPSRET=$UPSRET"{\"debname\":\"${NAME}\",\"debver\":\"${INSTALLED_VER}\",\"state\":\"$UPS_CHK_CNT\",\"path\":\"$UPS_FILE_PATH\"}"
                         
@@ -232,10 +232,10 @@ do
         sleep 1
 
 
-        DEL_CHK_CNT=`dpkg --get-selections | grep $I | wc -l`
+        DEL_CHK_CNT=`dpkg --get-selections | grep $I | grep -v "[[:graph:]]$I\|$I[[:graph:]]" | wc -l`
         echo "del chk wc -l is ==> $DEL_CHK_CNT" >>$LOGFILE
 
-        DEL_PKG_VER=`apt version $I`
+        DEL_PKG_VER=`dpkg -l | grep $I | awk '{print $3}'`
 
 
         DELRET=$DELRET"{\"debname\":\"${I}\",\"debver\":\"${DEL_PKG_VER}\",\"state\":\"$DEL_CHK_CNT\",\"path\":\"\"}"


### PR DESCRIPTION
#190 해당 이슈에 대한 pr입니다.
에이전트의 업데이트 정책 수행 파일인 updtjob.sh 의 프로그램 버전 확인 명령어를 타 os (구름, ubuntu, debian) 에서 호환되도록 수정하였습니다.