### PR TITLE
디바이스 차단 메시지 호환성 수정

### DIFF
--- a/hamonize-connector/debian/control
+++ b/hamonize-connector/debian/control
@@ -8,6 +8,15 @@ Homepage: https://hamonikr.org
 
 Package: hamonize-connect
 Architecture: any
-Depends: jq
+Depends: curl,
+         jq,
+         openssh-server,
+         collectd-core,
+         timeshift,
+         openvpn,
+         network-manager-openvpn,
+         ufw,
+         usbutils,
+         build-essential
 Description: Agent program that manages pc in Harmonize projects.
  하모나이즈 프로젝트에서 pc를 관리하는 에이전트 프로그램입니다.

--- a/hamonize-connector/src/shell/usb-lockdown/usb-lockdown-work
+++ b/hamonize-connector/src/shell/usb-lockdown/usb-lockdown-work
@@ -28,14 +28,12 @@ case $1 in
                 PRODUCT=$(cat /sys${DEVPATH%/*}/idProduct)
             
             fi
-
-            sudo -u ${RUID} DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/${RUSER_UID}/bus" zenity --error --width=300 --height=100 --text "허용된 USB 만 사용 가능합니다.\n\n관리자에 의해서 이 USB 장치 사용이 금지되었습니다.\n\n관리자에게 >문의하세요.\n\nVendor:Product = $VENDOR:$PRODUCT"
-
+            su ${RUID} -c 'zenity --error --width=300 --height=100 --text "허용된 USB 만 사용 가능합니다.\n\n관리자에 의해서 이 USB 장치 사용이 금지되었습니다.\n\n관리자에게 >문의하세요.\n\nVendor:Product = '$VENDOR':'$PRODUCT'"'
+	    
             echo 0 | tee /sys${DEVPATH%/*}/authorized | tee -a $LOGFILE
             
 
             USBNMTMP=`lsusb | grep $VENDOR | grep $PRODUCT`
-           
             echo "{ \"datetime\":\"$DATETIME\", \"uuid\":\"$UUID\", \"vendor\": \"$VENDOR\", \"product\": \"$PRODUCT\", \"usbinfo\": \"$USBNMTMP\", \"user\": \"$USER\" }" >> $UNAUTHLOGFILE
         fi
     ;;


### PR DESCRIPTION
#194 해당 이슈에 대한 pr입니다. 다음 사항을 수정했습니다.
- 디바이스 차단 메시지가 보이지 않는 이슈를 해결해 구름os, linuxmint, ubuntu20.04, debian11 에서 테스트를 수행했습니다.
- 커넥터 설치시 의존성 패키지가 설치되도록 hamonize-connector/debian/control 파일을 수정했습니다.