### PR TITLE
apt 서버 정보 세팅 수정

### DIFF
--- a/hamonize-connector/src/shell/aptCheck.sh
+++ b/hamonize-connector/src/shell/aptCheck.sh
@@ -1,15 +1,14 @@
 #!/bin/bash
 
-. /etc/hamonize/propertiesJob/propertiesInfo.hm
-
 #=== hamonize apt repository check ====
 LOGFILE="/var/log/hamonize/propertiesJob/propertiesJob.log"
 APT_CHK_COUNT=`find /etc/apt/sources.list.d  -name hamonize.list | wc -l`
+APTURL=`cat /etc/hamonize/propertiesJob/propertiesInfo.hm | grep APTURL | awk -F'=' '{print $2}'`
 
 if [ ${APT_CHK_COUNT} = 0 ];
 then
 	echo "[hamonize apt is not repository....]" > $LOGFILE
-echo $APTURL
+	echo $APTURL
 	touch /etc/apt/sources.list.d/hamonize.list
 	echo "deb http://$APTURL hamonize main" | sudo tee -a /etc/apt/sources.list.d/hamonize.list
 	echo "deb-src http://$APTURL hamonize main" | sudo tee -a /etc/apt/sources.list.d/hamonize.list


### PR DESCRIPTION
#198 해당 이슈에 대한 pr입니다.
hamonize-connector/src/shell/aptCheck.sh 파일을 수정해 apt 서버 정보를 읽어 저장하도록 수정했습니다.