### PR TITLE
커넥터의 의존성 패키지 정리

### DIFF
--- a/hamonize-connector/debian/control
+++ b/hamonize-connector/debian/control
@@ -10,13 +10,7 @@ Package: hamonize-connect
 Architecture: any
 Depends: curl,
          jq,
-         openssh-server,
-         collectd-core,
-         timeshift,
-         openvpn,
-         network-manager-openvpn,
          ufw,
-         usbutils,
-         build-essential
+         timeshift
 Description: Agent program that manages pc in Harmonize projects.
  하모나이즈 프로젝트에서 pc를 관리하는 에이전트 프로그램입니다.


### PR DESCRIPTION
#201 해당 이슈에 대한 pr입니다.
커넥터의 control 파일에 적힌 의존성 패키지 중 openssh-server 와 같이 불필요한 패키지를 제거하였습니다.