### PR TITLE
어드민] ubuntu20.04에서의 hamonize-server 시작 에러 해결

### DIFF
--- a/hamonize-admin/plugins/platform/common/PlatformSessionManager.cpp
+++ b/hamonize-admin/plugins/platform/common/PlatformSessionManager.cpp
@@ -22,6 +22,7 @@
  *
  */
 
+#include <QElapsedTimer>
 #include <QLocalServer>
 #include <QLocalSocket>
 #include <QMutexLocker>

--- a/hamonize-admin/plugins/platform/linux/LinuxServiceCore.cpp
+++ b/hamonize-admin/plugins/platform/linux/LinuxServiceCore.cpp
@@ -139,6 +139,8 @@ void LinuxServiceCore::startServer( const QString& login1SessionId, const QDBusO
 		return;
 	}
 
+	sessionEnvironment.insert( LinuxSessionFunctions::xdgSessionPathEnvVarName(), sessionPath );
+
 	// if pam-systemd is not in use, we have to set the XDG_SESSION_ID environment variable manually
 	if( sessionEnvironment.contains( LinuxSessionFunctions::xdgSessionIdEnvVarName() ) == false )
 	{

--- a/hamonize-admin/plugins/platform/linux/LinuxSessionFunctions.cpp
+++ b/hamonize-admin/plugins/platform/linux/LinuxSessionFunctions.cpp
@@ -275,13 +275,13 @@ QProcessEnvironment LinuxSessionFunctions::getSessionEnvironment( int sessionLea
 
 QString LinuxSessionFunctions::currentSessionPath()
 {
-	const auto xdgSessionId = QProcessEnvironment::systemEnvironment().value( xdgSessionIdEnvVarName() );
-	if( xdgSessionId.isEmpty() )
+	const auto xdgSessionPath = QProcessEnvironment::systemEnvironment().value( xdgSessionPathEnvVarName() );
+	if( xdgSessionPath.isEmpty() )
 	{
 		return QStringLiteral("/org/freedesktop/login1/session/self");
 	}
 
-	return QStringLiteral("/org/freedesktop/login1/session/%1").arg( xdgSessionId );
+	return xdgSessionPath;
 }
 
 

--- a/hamonize-admin/plugins/platform/linux/LinuxSessionFunctions.h
+++ b/hamonize-admin/plugins/platform/linux/LinuxSessionFunctions.h
@@ -104,6 +104,11 @@ public:
 	{
 		return QStringLiteral("XDG_SESSION_ID");
 	}
+	
+	static QString xdgSessionPathEnvVarName()
+	{
+		return QStringLiteral("XDG_SESSION_PATH");
+	}
 
 	static bool isOpen( const QString& session );
 	static bool isGraphical( const QString& session );

--- a/hamonize-admin/plugins/vncserver/x11vnc-builtin/BuiltinX11VncServer.cpp
+++ b/hamonize-admin/plugins/vncserver/x11vnc-builtin/BuiltinX11VncServer.cpp
@@ -32,7 +32,7 @@
 #include "X11VncConfigurationWidget.h"
 
 extern "C" int x11vnc_main( int argc, char * * argv );
-
+extern "C" int hasWorkingXShm();
 
 BuiltinX11VncServer::BuiltinX11VncServer( QObject* parent ) :
 	QObject( parent ),
@@ -72,11 +72,14 @@ bool BuiltinX11VncServer::runServer( int serverPort, const Password& password )
 		cmdline.append( extraArguments.split( QLatin1Char(' ') ) );
 	}
 
-	const auto systemEnv = QProcessEnvironment::systemEnvironment();
-	if( systemEnv.contains( QStringLiteral("XRDP_SESSION") ) )
+
+	if( hasWorkingXShm() == false )
 	{
+		vDebug() << "X shared memory extension not available - passing -noshm to x11vnc";
 		cmdline.append( QStringLiteral("-noshm") );
 	}
+
+	const auto systemEnv = QProcessEnvironment::systemEnvironment();
 
 	if( m_configuration.isXDamageDisabled() ||
 		// workaround for x11vnc when running in a NX session or a Thin client LTSP session

--- a/hamonize-admin/plugins/vncserver/x11vnc-builtin/x11vnc-hamonize.c
+++ b/hamonize-admin/plugins/vncserver/x11vnc-builtin/x11vnc-hamonize.c
@@ -5,3 +5,128 @@
 
 #include "x11vnc.c"
 #include "pm.c"
+
+#ifdef HAVE_XSHM
+
+#include <X11/Xlib.h>
+#include <X11/extensions/XShm.h>
+
+static int xshmOpCode = 0;
+static int xshmAttachErrorCount = 0;
+static XErrorHandler defaultXErrorHandler = NULL;
+
+static int handleXError( Display* display, XErrorEvent* error )
+{
+	if( xshmOpCode > 0 && error->request_code == xshmOpCode )
+	{
+		xshmAttachErrorCount++;
+        return 0;
+	}
+
+	return defaultXErrorHandler(display, error);
+}
+
+
+
+static XImage* createXShmTestImage( Display* display, XShmSegmentInfo* shm )
+{
+	shm->shmid = -1;
+	shm->shmaddr = (char *) -1;
+
+	int screen = DefaultScreen(display);
+
+	XImage* xim = XShmCreateImage(display, DefaultVisual(display, screen),
+								   DefaultDepth(display, screen),
+								   ZPixmap, NULL, shm, 1, 1);
+	if( xim == NULL )
+	{
+		return NULL;
+	}
+
+	shm->shmid = shmget(IPC_PRIVATE, xim->bytes_per_line * xim->height, IPC_CREAT | 0600);
+
+	if( shm->shmid == -1 )
+	{
+		return xim;
+	}
+
+	shm->shmaddr = xim->data = (char *) shmat(shm->shmid, NULL, 0);
+	shm->readOnly = 1;
+
+	if( shm->shmaddr == (char *)-1 )
+	{
+		return xim;
+	}
+
+	if( XShmAttach(display, shm) )
+	{
+		XSync(display, False);
+		XShmDetach(display, shm);
+	}
+	else
+	{
+		xshmAttachErrorCount++;
+	}
+
+    XSync(display, False);
+
+	return xim;
+}
+
+
+
+int hasWorkingXShm()
+{
+	xshmAttachErrorCount = 0;
+
+	char* displayName = NULL;
+	if( getenv("DISPLAY") )
+	{
+		displayName = getenv("DISPLAY");
+	}
+
+	Display* display = XOpenDisplay(displayName);
+	if( display == NULL )
+	{
+		return 0;
+	}
+
+	int op, ev, er;
+	if( XQueryExtension(display, "MIT-SHM", &op, &ev, &er) )
+	{
+		xshmOpCode = op;
+	}
+	else
+	{
+		XCloseDisplay(display);
+		return 0;
+	}
+
+	defaultXErrorHandler = XSetErrorHandler(handleXError);
+
+	XShmSegmentInfo shm;
+	XImage* xim = createXShmTestImage(display, &shm);
+
+	XSetErrorHandler(defaultXErrorHandler);
+
+	if( xim )
+	{
+		XDestroyImage(xim);
+	}
+
+	shm_delete(&shm);
+
+	XCloseDisplay(display);
+
+
+	return xshmAttachErrorCount == 0;
+}
+
+#else
+
+int hasWorkingXShm()
+{
+	return 0;
+}
+
+#endif

--- a/hamonize-admin/postinst
+++ b/hamonize-admin/postinst
@@ -14,3 +14,6 @@ if [ ! -x "$XDG_DESKTOP_MENU" ]; then
 else
   "$XDG_DESKTOP_MENU" install --mode system /usr/share/applications/hamonize-remote.desktop
 fi
+
+sudo systemctl enable /lib/systemd/system/hamonize.service
+sudo systemctl start hamonize.service


### PR DESCRIPTION
#125 해당 이슈에 대한 pr입니다.
ubuntu20.04에서 어드민의 호환성을 검증하는 과정에서 hamonize-server가 실행되지 않아 원격제어의 대상이 되지 못하는 이슈를 발견하였습니다.
해당 이슈를 해결하기 위해 veyon4.5.7 의 변경사항을 반영했습니다. (기존 사용 버전 : veyon 4.5.6)
또한, hamonize-admin/postinst를 수정해 패키지 설치시 하모나이즈 서비스가 자동 실행되도록 수정했습니다.