### PR TITLE
커넥터 - vpn 사용여부 설정 위치 변경

### DIFF
--- a/hamonize-connector/src/main.js
+++ b/hamonize-connector/src/main.js
@@ -214,15 +214,15 @@ ipcMain.on('install_program_Ready', (event) => {
 			
 			console.log(obj[0]["vpn_used"]);
 			vpn_used = obj[0]["vpn_used"];
-		});
 
-		if(vpn_used == 1){
-			console.log("vpn install..");
-			install_program_ReadyAsync(event);
-		}else if(vpn_used == 0){
-			console.log("vpn bypass..");
-			event.sender.send('install_program_ReadyProcResult', 'Y');
-		}
+			if(vpn_used == 1){
+				console.log("vpn install..");
+				install_program_ReadyAsync(event);
+			}else if(vpn_used == 0){
+				console.log("vpn bypass..");
+				event.sender.send('install_program_ReadyProcResult', 'Y');
+			}
+		});
 
 	});
 
@@ -372,7 +372,7 @@ function setServerInfo() {
 	return new Promise(function (resolve, reject) {
 
 		console.log("====get Agent Server Info");
-		var getAgentInfo = "sh " + __dirname + "/shell/setServerInfo.sh";
+		var getAgentInfo = "bash " + __dirname + "/shell/setServerInfo.sh";
 
 		sudo.exec(getAgentInfo, options,
 			function (error, stdout, stderr) {


### PR DESCRIPTION
#212 해당 이슈에 대한 pr입니다.
다음 사항을 수정했습니다.
- vpn_used 정보를 받아온 후 설정하도록 위치 수정
- shell/setServerInfo.sh 파일 실행시 sh 로 실행하면 버그가 발생해 bash 로 실행하도록 수정