### PR TITLE
#253 hamonizeInitJob.sh 패키지 설치여부 체크, ufw allow 11100

### DIFF
--- a/hamonize-connector/src/shell/hamonizeInitJob.sh
+++ b/hamonize-connector/src/shell/hamonizeInitJob.sh
@@ -91,13 +91,18 @@ if [ $CHK_AGNET_INSTALLED = 0  ]; then
         sudo apt-get install hamonize-agent -y >> $LOGFILE
 fi
 
-
 CHK_AGENT=`apt list --upgradable 2>/dev/null | grep hamonize-agent | wc -l`
 echo "agent upgrade able is =="$CHK_AGENT >> $LOGFILE
 if [ $CHK_AGENT -gt 0  ]; then
         sudo apt-get --only-upgrade install hamonize-agent -y >/dev/null 2>&1
 fi
 
+
+CHK_PCMNGR_INSTALLED=`dpkg-query -W | grep hamonize-process-mngr | wc -l`
+echo "pcmngr install checked is =="$CHK_PCMNGR_INSTALLED >> $LOGFILE
+if [ $CHK_PCMNGR_INSTALLED = 0  ]; then
+        sudo apt-get install hamonize-process-mngr -y >> $LOGFILE
+fi
 
 CHK_PCMNGR=`apt list --upgradable 2>/dev/null | grep hamonize-process-mngr | wc -l`
 echo "pcmngr upgrade able is =="$CHK_PCMNGR >> $LOGFILE
@@ -106,6 +111,12 @@ if [ $CHK_PCMNGR -gt 0  ]; then
 fi
 
 
+CHK_ADMIN_INSTALLED=`dpkg-query -W | grep hamonize-user | wc -l`
+echo "hamonize-user install checked is =="$CHK_ADMIN_INSTALLED >> $LOGFILE
+if [ $CHK_ADMIN_INSTALLED = 0  ]; then
+        sudo apt-get install hamonize-user -y >> $LOGFILE
+fi
+
 CHK_ADMIN=`apt list --upgradable 2>/dev/null | grep hamonize-user | wc -l`
 echo "hamonize-user upgrade able is =="$CHK_ADMIN >> $LOGFILE
 if [ $CHK_ADMIN -gt 0  ]; then
@@ -113,3 +124,6 @@ if [ $CHK_ADMIN -gt 0  ]; then
 fi
 
 echo "$DATETIME] resboot==========END" >>$LOGFILE
+
+echo "$DATETIME] hamonize-user 필수 포트 allow 11100==========END" >>$LOGFILE
+sudo ufw allow 11100 >>$LOGFILE


### PR DESCRIPTION
커넥터 설치 후 pc 재부팅시 서버 정보를 업데이트하고 필수 패키지를 업그레이드 하기 위해 실행되는 hamonizeInitJob.sh 파일에서 필수 패키지의 설치 여부를 확인하도록 수정, hamonize-user 가 사용하는 11100 포트가 항상 allow 되도록 수정하였습니다.