### PR TITLE
Added VScode case in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ hamonize-admin/svg
 hamonize-admin/Makefile
 hamonize-admin/plugins/addons
 hamonize-admin/plugins/extra
+
+# VisualStudioCode
+.vscode
+.vscode/*
+.history


### PR DESCRIPTION
This commit is to add VScode statements in the .gitignore file because
many developers currently use the IDE VS Code (https://code.visualstudio.com/)

Signed-off-by: Geunsik Lim <leemgs@gmail.com>