### PR TITLE
Removed unused variable 'index'

### DIFF
--- a/hamonize-admin/core/src/NetworkObjectDirectory.cpp
+++ b/hamonize-admin/core/src/NetworkObjectDirectory.cpp
@@ -88,14 +88,12 @@ const NetworkObject& NetworkObjectDirectory::object( NetworkObject::ModelId pare
 	const auto it = m_objects.constFind( parent );
 	if( it != m_objects.end() )
 	{
-		int index = 0;
 		for( const auto& entry : *it )
 		{
 			if( entry.modelId() == object )
 			{
 				return entry;
 			}
-			++index;
 		}
 	}
 


### PR DESCRIPTION
This commit is to remove unused variable 'index' after this variable is
modified (e.g., ++index).

Signed-off-by: Geunsik Lim <leemgs@gmail.com>