### PR TITLE
adminkey: Fixed a bug in the getAdminkey.sh

### DIFF
--- a/adminkey/getAdminkey.sh
+++ b/adminkey/getAdminkey.sh
@@ -15,7 +15,7 @@
 
 ## test server
 CENTERURL="192.168.0.210:8080"
-USER= whoami
+USER=$(whoami)
 
 echo "user..? $USER"
 echo "PWD..? $PWD"


### PR DESCRIPTION
This commit is to fix an incorrect statement that tries to get the return value from the 'whoami' command. 


Signed-off-by: Geunsik Lim <leemgs@gmail.com>