### PR TITLE
Set OOMScoreAdjust=-1000 to avoid OOMing Hamonize process

### DIFF
--- a/hamonize-agent/lib/systemd/system/hamonize-agent.service
+++ b/hamonize-agent/lib/systemd/system/hamonize-agent.service
@@ -6,6 +6,7 @@ StartLimitBurst=5
 
 [Service]
 Type=simple
+OOMScoreAdjust=-1000
 Restart=always
 RestartSec=5
 WorkingDirectory=/usr/share/hamonize-agent


### PR DESCRIPTION
The OOMScoreAdjust sets the adjustment level for the Out-Of-Memory killer
for executed processes. According to the official manual of Systemd, we can 
take an integer between -1000 (to disable OOM killing for this process) and 1000 
(to make killing of this process under memory pressure very likely).

* https://www.freedesktop.org/software/systemd/man/systemd.exec.html#OOMScoreAdjust=

Signed-off-by: Geunsik Lim <leemgs@gmail.com>