### PR TITLE
Document: Fixed typos in the readme.md file

### DIFF
--- a/hamonize-agent/readme.md
+++ b/hamonize-agent/readme.md
@@ -2,14 +2,14 @@
 ## Hamonize-agent?
 ![license](https://img.shields.io/badge/Apache-License2.0-green.svg)
 
-하모나이즈 에이전트는 개별 pc에 설치되어 하모나이즈 센터에서 배포된 정책을 수행하는 에이전트 프로그램입니다
+하모나이즈 에이전트는 개별 PC에 설치되어 하모나이즈 센터에서 배포된 정책을 수행하는 에이전트 프로그램입니다.
 
 <br>
 
 ### 데비안 패키징 방법
 
 hamonize-agent/ 위치에서 
-```
+```bash
 dpkg-buildpackage -T clean
 dpkg-buildpackage -b -us -uc -ui 
 ```
@@ -17,12 +17,12 @@ dpkg-buildpackage -b -us -uc -ui
 
 ### 소스 빌드하기
 1) src/ 위치에서 
-   ```
+    ```bash
     npm install
     ```   
 
 2)  실행하기
-    ```
+    ```bash
     npm run start 
     ```
 
@@ -30,17 +30,17 @@ dpkg-buildpackage -b -us -uc -ui
 
 
 ### 필수 디렉토리
-- hamonize-agent 설치되는 위치 : /usr/share/hamonize-agent/
-- log 파일들 위치 : /var/log/hamonize/agentJob
-- hamonize-center와 연동시  필요한 파일들의 위치 : /etc/hamonize/
+- hamonize-agent가 설치되는 위치: /usr/share/hamonize-agent/
+- log 파일들의 위치: /var/log/hamonize/agentJob/
+- hamonize-center와 연동시 필요한 파일들의 위치: /etc/hamonize/
 
 <br>
 
-### 로그확인
-- agent 로그 
+### 로그 확인
+- agent의 로그를 열람하는 방법입니다. 
+  ```bash
+  tail -f /var/log/hamonize/agentJob/agentjob.log.{date}
   ```
-  tail -f /var/log/hamonize/agentJob/agentjob.log.{해당 date}
-   ```
 
 
 
@@ -53,11 +53,11 @@ dpkg-buildpackage -b -us -uc -ui
 *  Code Style
    * Hamonize-Agent는 NodeJS + Shell Script 사용
     - Linux Coding Style은 해당 [여기]( https://www.kernel.org/doc/html/latest/process/coding-style.html) 를 참조하시기 바랍니다.  
-    - Node.Js 는 Prettier Module를 사용
-    - 사용방법 :  
+    - Node.Js 는 Prettier Module를 사용합니다.
+    - 사용방법:  
       1. npm i -D prettier 
-      2. Package.json에 아래 내용 추가 <br><br>
-      ```
+      2. Package.json에 아래 내용 추가하여 주세요. <br><br>
+      ```bash
       {
           ...
           "scripts": {


### PR DESCRIPTION
This commit is to fix typos in the readme.md file in the ./hamonize-agen folder.