### PR TITLE
Added ctag in the .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,5 @@ hamonize-admin/plugins/extra
 .vscode/*
 .history
 
-# CTag/tags
+# CTag
+/tags

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ hamonize-admin/plugins/extra
 .vscode
 .vscode/*
 .history
+
+# CTag/tags


### PR DESCRIPTION
This commit is to append the ctag file in the .gitignore file. It is to handle the ctag files that can be added by ctag user.

Signed-off-by: Geunsik Lim <leemgs@gmail.com>