### PR TITLE
Updated the changelog file for Debian packaging

### DIFF
--- a/hamonize-agent/debian/changelog
+++ b/hamonize-agent/debian/changelog
@@ -1,6 +1,6 @@
 hamonize-agent (1.0.1) stable; urgency=low
 
-  * Initial release. 1.0.1
+  * Minor update 1.0.1
 
  -- HamoniKR <pkg@hamonikr.org>  Wed, 26 May 2021 15:51:27 +0900
 


### PR DESCRIPTION
This commit is to fix incorrect description for Debian packaging. 
Now that "Initial release" has to be existed at one consistently, we need to update statements after first release.
Actually, this description can be displayed with "dpkg" command on the Debian/Ubuntu/Mint/Hamonikr distribution 

Signed-off-by: Geunsik Lim <leemgs@gmail.com>