### PR TITLE
Fix: Updated review list in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,4 @@
 # all member IDs directly to avoid unexpected situations.
 
 # In order that all members of a repository are supposed to review each other
-* @jullee96 @yeji0407 @1942kg
+* @jullee96 @yeji0407 @gon1942


### PR DESCRIPTION
This commit is to update the existing review list of the CODEOWNERS file in order to 
replace  @1942kg  (deprecated) with @gon1942.

Signed-off-by: Geunsik Lim <leemgs@gmail.com>