### PR TITLE
fix: added ufw status in securityjob.sh

### DIFF
--- a/hamonize-agent/src/shell/securityjob.sh
+++ b/hamonize-agent/src/shell/securityjob.sh
@@ -57,4 +57,5 @@ done;
 IFS=$OLD_IFS
 
 sudo ufw disable
+sudo ufw status
 sudo iptables -F


### PR DESCRIPTION
This commit is to append the "ufw status" statement in
to the securityjob.sh file in order to confirm the execution
resultnof the "ufw disable" statement.

Signed-off-by: Geunsik Lim <leemgs@gmail.com>