### PR TITLE
Refactor: added binary files in the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ hamonize-connector/src/node-modules/*
 
 # CTag
 /tags
+
+
+# binary files
+*.so
+*.o
+*.a


### PR DESCRIPTION
This commit is to append binary files into the 
.gitignore file to prevent importing unnecessary files in to
the Github repository.

Signed-off-by: Geunsik Lim <leemgs@gmail.com>